### PR TITLE
Make explictly a dynamic SPM package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .iOS(.v12),
     ],
     products: [
-        .library(name: "ScreenCorners", targets: ["ScreenCorners"]),
+        .library(name: "ScreenCorners", type: .dynamic, targets: ["ScreenCorners"]),
     ],
     targets: [
         .target(name: "ScreenCorners"),


### PR DESCRIPTION
Addresses this error https://forums.swift.org/t/objc-flag-causes-duplicate-symbols-with-swift-packages/27926/17
