### PR TITLE
Update iPhone 16 corner radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ The following values were reported for various devices with rounded corners:
 | iPhone X, Xs, Xs Max, 11 Pro, 11 Pro Max | 39.0 |
 | iPhone Xr, 11 | 41.5 |
 | iPhone 12 mini, 13 mini | 44.0 |
-| iPhone 12, 12 Pro, 13 Pro, 14 | 47.33 |
-| iPhone 12 Pro Max, 13 Pro Max, 14 Plus | 53.33 |
+| iPhone 12, 12 Pro, 13 Pro, 14, 16 Pro | 47.33 |
+| iPhone 12 Pro Max, 13 Pro Max, 14 Plus, 16 Pro Max | 53.33 |
 | iPhone 14 Pro, 14 Pro Max, 15, 15 Plus, 15 Pro, 15 Pro Max, 16, 16 Plus | 55.0 |
-| iPhone 16 Pro, 16 Pro Max | 62.0 |
 | iPad Air / iPad Pro 11-inch / 12.9-inch | 18.0 |


### PR DESCRIPTION
Maybe I got it wrong, when testing iPhone 16 simulator I get different values compared to the current list.
```
iPhone 16 55.0 ✅
iPhone 16 Plus 55.0 ✅
iPhone 16 Pro 47.3 ❌
iPhone 16 Pro Max 53.3 ❌
```